### PR TITLE
Fixed duplicated text numbers after scroll

### DIFF
--- a/src/js/rulez.js
+++ b/src/js/rulez.js
@@ -199,7 +199,7 @@
                 var startTextPos = pixelCurrentPosition - offset;
                 for (var j = 0; j < textElements.length; j++) {
                     var textElement = textElements[j];
-                    var text = Math.floor((startTextPos + (j - additionalDivisionsAmount * amountPerMaxDistance) * textConfig.pixelGap) * scale);
+                    var text = Math.round((startTextPos + (j - additionalDivisionsAmount * amountPerMaxDistance) * textConfig.pixelGap) * scale *100)/100;
                     if (textConfig.showUnits) {
                         text = addUnits(text);
                     }


### PR DESCRIPTION
When having a value like 9,999999999999998 it was showing 9. 
So, it was showing ..., 9 ,9, 11, ... because math.floor() returns 9 when the value is 9,9999999999998.
Fixed by replacing math.floor with math.round.